### PR TITLE
Bug: Use specific Docker Compose file in build.xml

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -22,7 +22,7 @@
       </try>
       <finally>
         <exec executable="docker" failonerror="true">
-          <arg line="compose down" />
+          <arg line="compose -f refimpl/container/compose.yml down" />
         </exec>
       </finally>
     </trycatch>


### PR DESCRIPTION
### Issue
Running `docker compose down` in the `finally` block, but it fails because there is no `compose.yml` file in the project root directory.
```
~~~~
     [exec] [INFO] Reactor Summary for quarkus-auth-adapter 0.8-SNAPSHOT:
     [exec] [INFO] 
     [exec] [INFO] quarkus-auth-adapter ............................... SUCCESS [  0.883 s]
     [exec] [INFO] quarkus-auth-adapter-api ........................... SUCCESS [  7.601 s]
     [exec] [INFO] quarkus-auth-adapter-keycloak ...................... SUCCESS [ 22.126 s]
     [exec] [INFO] quarkus-auth-adapter-container ..................... SUCCESS [01:12 min]
     [exec] [INFO] quarkus-auth-adapter-keycloak-refimpl .............. SUCCESS [ 45.061 s]
     [exec] [INFO] quarkus-auth-adapter-svelte-refimpl ................ SUCCESS [  9.163 s]
     [exec] [INFO] poc-auth-e2etest ................................... SUCCESS [01:55 min]
     [exec] [INFO] ------------------------------------------------------------------------
     [exec] [INFO] BUILD SUCCESS
     [exec] [INFO] ------------------------------------------------------------------------
     [exec] [INFO] Total time:  04:34 min
     [exec] [INFO] Finished at: 2026-04-28T11:14:36+09:00
     [exec] [INFO] ------------------------------------------------------------------------
     [exec] no configuration file provided: not found
[INFO] ------------------------------------------------------------------------
[INFO] Reactor Summary for quarkus-auth-adapter 0.8-SNAPSHOT:
[INFO] 
[INFO] quarkus-auth-adapter ............................... FAILURE [04:36 min]
[INFO] quarkus-auth-adapter-api ........................... SKIPPED
[INFO] quarkus-auth-adapter-keycloak ...................... SKIPPED
[INFO] quarkus-auth-adapter-container ..................... SKIPPED
[INFO] poc-auth-e2etest ................................... SKIPPED
[INFO] quarkus-auth-adapter-keycloak-refimpl .............. SKIPPED
[INFO] quarkus-auth-adapter-svelte-refimpl ................ SKIPPED
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  04:36 min
[INFO] Finished at: 2026-04-28T11:14:36+09:00
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-antrun-plugin:1.8:run (default-cli) on project quarkus-auth-adapter: An Ant BuildException has occured: The following error occurred while executing this line:
[ERROR] /Users/miniadmin3/jenkins/jenkins-slave/workspace/pal-qaa-deploy/build.xml:24: exec returned: 14
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoExecutionException
```

Solution
Use specific Docker Compose file in build.xml