### PR TITLE
Support: Fix Keycloak enforcer property and remove TLS

### DIFF
--- a/refimpl/keycloak-refimpl/src/main/resources/application.properties
+++ b/refimpl/keycloak-refimpl/src/main/resources/application.properties
@@ -20,7 +20,7 @@ quarkus.keycloak.admin-client.password=${auth.password}
 
 quarkus.keycloak.devservices.enabled=false
 
-quarkus.keycloak.policy-enforcer.enable=true
+quarkus.keycloak.policy-enforcer.enabled=true
 quarkus.keycloak.policy-enforcer.lazy-load-paths=false
 quarkus.keycloak.policy-enforcer.paths.1.path=/*
 quarkus.keycloak.policy-enforcer.paths.1.enforcement-mode=DISABLED
@@ -28,4 +28,3 @@ quarkus.keycloak.policy-enforcer.paths.1.enforcement-mode=DISABLED
 quarkus.oidc.auth-server-url=http://localhost:${auth.port}/realms/${auth.realm}
 quarkus.oidc.client-id=${auth.clientId}
 quarkus.oidc.credentials.secret=${auth.clientSecret}
-quarkus.oidc.tls.verification=none


### PR DESCRIPTION
### Issue

quarkus.keycloak.policy-enforcer.enable
```
[WARNING] [io.quarkus.config] The "quarkus.keycloak.policy-enforcer.enable" config property is deprecated and should not be used anymore.
```

quarkus.oidc.tls.verification
```
WARN  [io.quarkus.config] (main) The "quarkus.oidc.tls.verification" config property is deprecated and should not be used anymore.
```

### Solution
- `quarkus.keycloak.policy-enforcer.enable` ⇒ `quarkus.keycloak.policy-enforcer.enabled`
  - https://quarkus.io/guides/security-keycloak-authorization#quarkus-keycloak-authorization_quarkus-keycloak-policy-enforcer-enabled:~:text=Environment%20variable%3A%20QUARKUS_KEYCLOAK_POLICY_ENFORCER_ENABLED
- Delete `quarkus.oidc.tls.verification=none` because server-url is not https.