### PR TITLE
Support: Replace quarkus-junit5 with quarkus-junit

### DIFF
--- a/refimpl/keycloak-refimpl/pom.xml
+++ b/refimpl/keycloak-refimpl/pom.xml
@@ -44,7 +44,7 @@
 
     <dependency>
       <groupId>io.quarkus</groupId>
-      <artifactId>quarkus-junit5</artifactId>
+      <artifactId>quarkus-junit</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
### Issue
```
[WARNING] The artifact io.quarkus:quarkus-junit5:jar:3.33.1 has been relocated to io.quarkus:quarkus-junit:jar:3.33.1: Update the artifactId in your project build file. Refer to https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31 for more information.
```

### Solution
Rename:  `quarkus-junit5` ⇒ `quarkus-junit`

### Note
https://github.com/quarkusio/quarkus/wiki/Migration-Guide-3.31#junit-6-gear-white_check_mark