### PR TITLE
Support: Update @sveltejs/kit to ^2.58.0

### DIFF
--- a/refimpl/svelte-refimpl/package.json
+++ b/refimpl/svelte-refimpl/package.json
@@ -18,7 +18,7 @@
     "@eslint/compat": "^1.2.5",
     "@eslint/js": "^9.18.0",
     "@sveltejs/adapter-auto": "^6.0.1",
-    "@sveltejs/kit": "^2.26.1",
+    "@sveltejs/kit": "^2.58.0",
     "@sveltejs/vite-plugin-svelte": "^6.1.0",
     "eslint": "^9.18.0",
     "eslint-config-prettier": "^10.0.1",

--- a/refimpl/svelte-refimpl/pnpm-lock.yaml
+++ b/refimpl/svelte-refimpl/pnpm-lock.yaml
@@ -20,10 +20,10 @@ importers:
         version: 9.32.0
       '@sveltejs/adapter-auto':
         specifier: ^6.0.1
-        version: 6.0.1(@sveltejs/kit@2.26.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))
+        version: 6.0.1(@sveltejs/kit@2.58.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))
       '@sveltejs/kit':
-        specifier: ^2.26.1
-        version: 2.26.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3))
+        specifier: ^2.58.0
+        version: 2.58.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^6.1.0
         version: 6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3))
@@ -457,6 +457,9 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
   '@sveltejs/acorn-typescript@1.0.5':
     resolution: {integrity: sha512-IwQk4yfwLdibDlrXVE04jTZYlLnwsTT2PIOQQGNLWfjavGifnk1JD1LcZjZaBTRcxZu2FfPfNLOE04DSu9lqtQ==}
     peerDependencies:
@@ -467,14 +470,21 @@ packages:
     peerDependencies:
       '@sveltejs/kit': ^2.0.0
 
-  '@sveltejs/kit@2.26.1':
-    resolution: {integrity: sha512-FwDhHAoXYUGnYndrrEzEYcKdYWpSoRKq4kli29oMe83hLri4/DOGQk3xUgwjDo0LKpSmj5M/Sj29/Ug3wO0Cbg==}
+  '@sveltejs/kit@2.58.0':
+    resolution: {integrity: sha512-kT9GCN8yJTkCK1W+Gi/bvGooWAM7y7WXP+yd+rf6QOIjyoK1ERPrMwSufXJUNu2pMWIqruhFvmz+LbOqsEmKmA==}
     engines: {node: '>=18.13'}
     hasBin: true
     peerDependencies:
-      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0
+      '@opentelemetry/api': ^1.0.0
+      '@sveltejs/vite-plugin-svelte': ^3.0.0 || ^4.0.0-next.1 || ^5.0.0 || ^6.0.0-next.0 || ^7.0.0
       svelte: ^4.0.0 || ^5.0.0-next.0
-      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0
+      typescript: ^5.3.3 || ^6.0.0
+      vite: ^5.0.3 || ^6.0.0 || ^7.0.0-beta.0 || ^8.0.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      typescript:
+        optional: true
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.0':
     resolution: {integrity: sha512-iwQ8Z4ET6ZFSt/gC+tVfcsSBHwsqc6RumSaiLUkAurW3BCpJam65cmHw0oOlDMTO0u+PZi9hilBRYN+LZNHTUQ==}
@@ -726,9 +736,6 @@ packages:
 
   destr@2.0.5:
     resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
-
-  devalue@5.1.1:
-    resolution: {integrity: sha512-maua5KUiapvEwiEAe+XnlZ3Rh0GD+qI1J/nb9vrJc3muPXvcF/8gXYTWF76+5DAqHyDUtOIImEuo0YKE9mshVw==}
 
   devalue@5.7.1:
     resolution: {integrity: sha512-MUbZ586EgQqdRnC4yDrlod3BEdyvE4TapGYHMW2CiaW+KkkFmWEFqBUaLltEZCGi0iFXCEjRF0OjF0DV2QHjOA==}
@@ -1215,8 +1222,8 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  set-cookie-parser@2.7.1:
-    resolution: {integrity: sha512-IOc8uWeOZgnb3ptbCURJWNjWUPcO3ZnTTdzsurqERrP6nPyv+paC55vJM0LpOlT2ne+Ix+9+CRG1MNLlyZ4GjQ==}
+  set-cookie-parser@3.1.0:
+    resolution: {integrity: sha512-kjnC1DXBHcxaOaOXBHBeRtltsDG2nUiUni+jP92M9gYdW12rsmx92UsfpH7o5tDRs7I1ZZPSQJQGv3UaRfCiuw==}
 
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
@@ -1720,31 +1727,35 @@ snapshots:
   '@rollup/rollup-win32-x64-msvc@4.46.1':
     optional: true
 
+  '@standard-schema/spec@1.1.0': {}
+
   '@sveltejs/acorn-typescript@1.0.5(acorn@8.15.0)':
     dependencies:
       acorn: 8.15.0
 
-  '@sveltejs/adapter-auto@6.0.1(@sveltejs/kit@2.26.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))':
+  '@sveltejs/adapter-auto@6.0.1(@sveltejs/kit@2.58.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))':
     dependencies:
-      '@sveltejs/kit': 2.26.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3))
+      '@sveltejs/kit': 2.58.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3))
 
-  '@sveltejs/kit@2.26.1(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3))':
+  '@sveltejs/kit@2.58.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(typescript@5.9.3)(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
+      '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.5(acorn@8.15.0)
       '@sveltejs/vite-plugin-svelte': 6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3))
       '@types/cookie': 0.6.0
       acorn: 8.15.0
       cookie: 0.6.0
-      devalue: 5.1.1
+      devalue: 5.7.1
       esm-env: 1.2.2
       kleur: 4.1.5
       magic-string: 0.30.17
       mrmime: 2.0.1
-      sade: 1.8.1
-      set-cookie-parser: 2.7.1
+      set-cookie-parser: 3.1.0
       sirv: 3.0.1
       svelte: 5.55.4(@typescript-eslint/types@8.59.0)
       vite: 7.3.2(jiti@2.6.1)(yaml@2.8.3)
+    optionalDependencies:
+      typescript: 5.9.3
 
   '@sveltejs/vite-plugin-svelte-inspector@5.0.0(@sveltejs/vite-plugin-svelte@6.1.0(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3)))(svelte@5.55.4(@typescript-eslint/types@8.59.0))(vite@7.3.2(jiti@2.6.1)(yaml@2.8.3))':
     dependencies:
@@ -2003,8 +2014,6 @@ snapshots:
   defu@6.1.7: {}
 
   destr@2.0.5: {}
-
-  devalue@5.1.1: {}
 
   devalue@5.7.1: {}
 
@@ -2477,7 +2486,7 @@ snapshots:
 
   semver@7.7.4: {}
 
-  set-cookie-parser@2.7.1: {}
+  set-cookie-parser@3.1.0: {}
 
   shebang-command@2.0.0:
     dependencies:


### PR DESCRIPTION
### Issue
```
This reference only captures the initial value of stores / page. Did you mean to reference it inside a closure instead?
```

### Details
```
     [exec] vite v7.3.2 building ssr environment for production...
     [exec] transforming...
     [exec] 13:44:20 [vite-plugin-svelte] .svelte-kit/generated/root.svelte:11:27 This reference only captures the initial value of `stores`. Did you mean to reference it inside a closure instead?
     [exec] https://svelte.dev/e/state_referenced_locally
     [exec]  9: 
     [exec] 10:   if (!browser) {
     [exec] 11:     setContext('__svelte__', stores);
     [exec]                                        ^
     [exec] 12:   }
     [exec] 13: 
     [exec] 13:44:20 [vite-plugin-svelte] .svelte-kit/generated/root.svelte:17:2 This reference only captures the initial value of `stores`. Did you mean to reference it inside a closure instead?
     [exec] https://svelte.dev/e/state_referenced_locally
     [exec] 15:     $effect.pre(() => stores.page.set(page));
     [exec] 16:   } else {
     [exec] 17:     stores.page.set(page);
     [exec]               ^
     [exec] 18:   }
     [exec] 19:   $effect(() => {
     [exec] 13:44:20 [vite-plugin-svelte] .svelte-kit/generated/root.svelte:17:18 This reference only captures the initial value of `page`. Did you mean to reference it inside a closure instead?
     [exec] https://svelte.dev/e/state_referenced_locally
     [exec] 15:     $effect.pre(() => stores.page.set(page));
     [exec] 16:   } else {
     [exec] 17:     stores.page.set(page);
     [exec]                             ^
     [exec] 18:   }
     [exec] 19:   $effect(() => {
     [exec] ✓ 161 modules transformed.
     [exec] rendering chunks...
     [exec] vite v7.3.2 building client environment for production...
     [exec] transforming...
     [exec] 13:44:21 [vite-plugin-svelte] .svelte-kit/generated/root.svelte:11:27 This reference only captures the initial value of `stores`. Did you mean to reference it inside a closure instead?
     [exec] https://svelte.dev/e/state_referenced_locally
     [exec]  9: 
     [exec] 10:   if (!browser) {
     [exec] 11:     setContext('__svelte__', stores);
     [exec]                                        ^
     [exec] 12:   }
     [exec] 13: 
     [exec] 13:44:21 [vite-plugin-svelte] .svelte-kit/generated/root.svelte:17:2 This reference only captures the initial value of `stores`. Did you mean to reference it inside a closure instead?
     [exec] https://svelte.dev/e/state_referenced_locally
     [exec] 15:     $effect.pre(() => stores.page.set(page));
     [exec] 16:   } else {
     [exec] 17:     stores.page.set(page);
     [exec]               ^
     [exec] 18:   }
     [exec] 19:   $effect(() => {
     [exec] 13:44:21 [vite-plugin-svelte] .svelte-kit/generated/root.svelte:17:18 This reference only captures the initial value of `page`. Did you mean to reference it inside a closure instead?
     [exec] https://svelte.dev/e/state_referenced_locally
     [exec] 15:     $effect.pre(() => stores.page.set(page));
     [exec] 16:   } else {
     [exec] 17:     stores.page.set(page);
     [exec]                             ^
     [exec] 18:   }
     [exec] 19:   $effect(() => {
```

### Solution
Update @sveltejs to apply fix below.
- https://github.com/sveltejs/kit/blob/main/packages/kit/CHANGELOG.md#:~:text=fix%3A%20suppress%20state_referenced_locally%20warnings%20in%20.svelte%2Dkit/generated/root.svelte%20(%2315013)