### PR TITLE
Feature: Add /me endpoint to return current user

### DIFF
--- a/lib/api/src/main/java/dev/aulait/qaa/api/AuthController.java
+++ b/lib/api/src/main/java/dev/aulait/qaa/api/AuthController.java
@@ -14,10 +14,10 @@ public interface AuthController {
 
   static final String BASE_PATH = "auth";
   static final String LOGIN_PATH = "/login";
+  static final String ME_PATH = "/me";
+  static final String REFRESH_TOKEN_PATH = "/refresh-token";
   static final String FORGOT_PASSWORD_PATH = "/forgot-password";
   static final String RESET_PASSWORD_PATH = "/reset-password";
-  static final String REFRESH_TOKEN_PATH = "/refresh-token";
-  static final String ME_PATH = "/me";
   static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
   @POST

--- a/lib/api/src/main/java/dev/aulait/qaa/api/AuthController.java
+++ b/lib/api/src/main/java/dev/aulait/qaa/api/AuthController.java
@@ -17,6 +17,7 @@ public interface AuthController {
   static final String FORGOT_PASSWORD_PATH = "/forgot-password";
   static final String RESET_PASSWORD_PATH = "/reset-password";
   static final String REFRESH_TOKEN_PATH = "/refresh-token";
+  static final String ME_PATH = "/me";
   static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
 
   @POST
@@ -29,6 +30,14 @@ public interface AuthController {
               mediaType = MediaType.APPLICATION_JSON,
               schema = @Schema(implementation = LoginResponse.class)))
   Response login(LoginRequest request);
+
+  @GET
+  @Path(ME_PATH)
+  @APIResponse(
+      responseCode = "200",
+      description =
+          "Returns the authenticated user's username, or empty string if not authenticated")
+  String me();
 
   @GET
   @Path(REFRESH_TOKEN_PATH)

--- a/lib/api/src/test/java/dev/aulait/qaa/api/AuthClient.java
+++ b/lib/api/src/test/java/dev/aulait/qaa/api/AuthClient.java
@@ -27,6 +27,10 @@ public class AuthClient {
     return client.post(BASE_PATH + LOGIN_PATH, request, ErrorResponse.class);
   }
 
+  public String me() {
+    return client.given().get(BASE_PATH + ME_PATH).then().extract().asString();
+  }
+
   public LoginResponse refreshToken() {
     Response response =
         client

--- a/lib/keycloak/src/main/java/dev/aulait/qaa/keycloak/KeycloakAuthController.java
+++ b/lib/keycloak/src/main/java/dev/aulait/qaa/keycloak/KeycloakAuthController.java
@@ -5,6 +5,7 @@ import dev.aulait.qaa.api.ForgotPasswordRequest;
 import dev.aulait.qaa.api.LoginRequest;
 import dev.aulait.qaa.api.LoginResponse;
 import dev.aulait.qaa.api.ResetPasswordRequest;
+import io.quarkus.security.identity.SecurityIdentity;
 import jakarta.ws.rs.CookieParam;
 import jakarta.ws.rs.Path;
 import jakarta.ws.rs.core.NewCookie;
@@ -30,6 +31,7 @@ public class KeycloakAuthController implements AuthController {
   private final AuthzClient authzClient;
   private final Keycloak keycloak;
   private final AuthHttpClient authHttpClient;
+  private final SecurityIdentity identity;
 
   @ConfigProperty(name = "auth.refreshToken.cookie.timeout")
   private int refreshTokenCookieTimeout;
@@ -54,6 +56,14 @@ public class KeycloakAuthController implements AuthController {
             .build();
 
     return Response.ok(loginResponse).cookie(cookie).build();
+  }
+
+  @Override
+  public String me() {
+    if (identity.isAnonymous()) {
+      return "";
+    }
+    return identity.getPrincipal().getName();
   }
 
   @Override

--- a/refimpl/keycloak-refimpl/src/integration-test/java/dev/aulait/qaa/qkref/AuthControllerIT.java
+++ b/refimpl/keycloak-refimpl/src/integration-test/java/dev/aulait/qaa/qkref/AuthControllerIT.java
@@ -64,4 +64,22 @@ class AuthControllerIT {
 
     assertEquals(Status.BAD_REQUEST.getStatusCode(), error.getStatusCode());
   }
+
+  @Test
+  void me_authenticated() {
+    authClient.login(AuthDataFactory.createProvider1());
+
+    String userName = authClient.me();
+
+    assertEquals("provider-1", userName);
+  }
+
+  @Test
+  void me_unauthenticated() {
+    AuthClient unauthenticatedClient = new AuthClient();
+
+    String userName = unauthenticatedClient.me();
+
+    assertEquals("", userName);
+  }
 }


### PR DESCRIPTION
### Summary
Add an API to retrieve the username of an authenticated user.

- Path
  - /auth/me
- Returns an empty string if the user is not authenticated

### Updates
- `AuthController.java` — Added the ME_PATH constant and the @GET @Path(“/me”) String me() method
-` KeycloakAuthController.java` — Injected SecurityIdentity and implemented me() (anonymous → “”, authenticated → identity.getPrincipal().getName())
- `AuthClient.java` — Added a test helper for me()
- `AuthControllerIT.java` (refimpl) — me_authenticated / me_unauthenticated
