### PR TITLE
Feature: Add logout endpoint and client support

### DIFF
--- a/lib/api/src/main/java/dev/aulait/qaa/api/AuthController.java
+++ b/lib/api/src/main/java/dev/aulait/qaa/api/AuthController.java
@@ -19,6 +19,7 @@ public interface AuthController {
   static final String FORGOT_PASSWORD_PATH = "/forgot-password";
   static final String RESET_PASSWORD_PATH = "/reset-password";
   static final String REFRESH_TOKEN_COOKIE_NAME = "refreshToken";
+  static final String LOGOUT_PATH = "/logout";
 
   @POST
   @Path(LOGIN_PATH)
@@ -60,4 +61,9 @@ public interface AuthController {
   @POST
   @Path(RESET_PASSWORD_PATH)
   Response resetPassword(ResetPasswordRequest request);
+
+  @POST
+  @Path(LOGOUT_PATH)
+  @APIResponse(responseCode = "200", description = "Logs out the user and clears the refresh token cookie")
+  Response logout(@CookieParam(REFRESH_TOKEN_COOKIE_NAME) String refreshToken);
 }

--- a/lib/api/src/test/java/dev/aulait/qaa/api/AuthClient.java
+++ b/lib/api/src/test/java/dev/aulait/qaa/api/AuthClient.java
@@ -57,6 +57,13 @@ public class AuthClient {
     return client.get(BASE_PATH + REFRESH_TOKEN_PATH, LoginResponse.class);
   }
 
+  public HttpCookie getRefreshTokenCookie() {
+    return cookieManager.getCookieStore().getCookies().stream()
+        .filter(c -> REFRESH_TOKEN_COOKIE_NAME.equals(c.getName()))
+        .findFirst()
+        .orElse(null);
+  }
+
   public ErrorResponse refreshTokenWithError() {
     URI baseUri = URI.create(client.getBaseUrl());
 
@@ -68,5 +75,10 @@ public class AuthClient {
     cookieManager.getCookieStore().add(baseUri, cookie);
 
     return client.get(BASE_PATH + REFRESH_TOKEN_PATH, ErrorResponse.class);
+  }
+
+  public void logout() {
+    client.post(BASE_PATH + LOGOUT_PATH, null, String.class);
+    accessToken = null;
   }
 }

--- a/lib/keycloak/src/main/java/dev/aulait/qaa/keycloak/KeycloakAuthController.java
+++ b/lib/keycloak/src/main/java/dev/aulait/qaa/keycloak/KeycloakAuthController.java
@@ -126,6 +126,7 @@ public class KeycloakAuthController implements AuthController {
     return Response.ok().build();
   }
 
+  @Override
   public Response resetPassword(ResetPasswordRequest request) {
     boolean result =
         authHttpClient.resetPassword(
@@ -139,5 +140,34 @@ public class KeycloakAuthController implements AuthController {
     }
 
     return Response.ok().build();
+  }
+  
+  @Override
+  public Response logout(@CookieParam(REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
+
+    if (refreshToken != null && !refreshToken.isEmpty()) {
+      Configuration config = authzClient.getConfiguration();
+      String realm = authzClient.getConfiguration().getRealm();
+
+      String logoutEndpoint =
+          config.getAuthServerUrl() + "/realms/" + realm + "/protocol/openid-connect/logout";
+
+      Http http = new Http(config, config.getClientCredentialsProvider());
+      http.post(logoutEndpoint)
+          .authentication()
+          .client()
+          .form()
+          .param("refresh_token", refreshToken)
+          .execute();
+    }
+
+    NewCookie expiredCookie =
+        new NewCookie.Builder(REFRESH_TOKEN_COOKIE_NAME)
+            .value("")
+            .maxAge(0)
+            .httpOnly(true)
+            .build();
+
+    return Response.ok().cookie(expiredCookie).build();
   }
 }

--- a/lib/keycloak/src/main/java/dev/aulait/qaa/keycloak/KeycloakAuthController.java
+++ b/lib/keycloak/src/main/java/dev/aulait/qaa/keycloak/KeycloakAuthController.java
@@ -14,6 +14,7 @@ import jakarta.ws.rs.core.Response;
 import jakarta.ws.rs.core.Response.Status;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.eclipse.microprofile.config.inject.ConfigProperty;
 import org.eclipse.microprofile.openapi.annotations.tags.Tag;
 import org.eclipse.microprofile.openapi.annotations.tags.Tags;
@@ -27,6 +28,7 @@ import org.keycloak.representations.idm.UserRepresentation;
 @Path(AuthController.BASE_PATH)
 @Tags(@Tag(name = "Auth Controller"))
 @RequiredArgsConstructor
+@Slf4j
 public class KeycloakAuthController implements AuthController {
 
   private final AuthzClient authzClient;
@@ -146,19 +148,24 @@ public class KeycloakAuthController implements AuthController {
   public Response logout(@CookieParam(REFRESH_TOKEN_COOKIE_NAME) String refreshToken) {
 
     if (refreshToken != null && !refreshToken.isEmpty()) {
-      Configuration config = authzClient.getConfiguration();
-      String realm = authzClient.getConfiguration().getRealm();
+      try {
+        Configuration config = authzClient.getConfiguration();
+        String realm = config.getRealm();
 
-      String logoutEndpoint =
-          config.getAuthServerUrl() + "/realms/" + realm + "/protocol/openid-connect/logout";
+        String logoutEndpoint =
+            config.getAuthServerUrl() + "/realms/" + realm + "/protocol/openid-connect/logout";
 
-      Http http = new Http(config, config.getClientCredentialsProvider());
-      http.post(logoutEndpoint)
-          .authentication()
-          .client()
-          .form()
-          .param("refresh_token", refreshToken)
-          .execute();
+        Http http = new Http(config, config.getClientCredentialsProvider());
+        http.post(logoutEndpoint)
+            .authentication()
+            .client()
+            .form()
+            .param("refresh_token", refreshToken)
+            .execute();
+      } catch (Exception e) {
+        // Do not handle exceptions to ensure that cookies are deleted.
+        log.warn("Keycloak logout request failed", e);
+      }
     }
 
     NewCookie expiredCookie =

--- a/refimpl/keycloak-refimpl/src/integration-test/java/dev/aulait/qaa/qkref/AuthControllerIT.java
+++ b/refimpl/keycloak-refimpl/src/integration-test/java/dev/aulait/qaa/qkref/AuthControllerIT.java
@@ -93,4 +93,12 @@ class AuthControllerIT {
     assertNull(me.getLastName());
     assertNull(me.getRoles());
   }
+
+  @Test
+  void logout() {
+    authClient.login(AuthDataFactory.createProvider1());
+    authClient.logout();
+
+    assertNull(authClient.getRefreshTokenCookie());
+  }
 }

--- a/refimpl/svelte-refimpl/src/lib/arch/api/Api.ts
+++ b/refimpl/svelte-refimpl/src/lib/arch/api/Api.ts
@@ -15,12 +15,18 @@ export interface ForgotPasswordRequest {
 }
 
 export interface LoginRequest {
-  userName?: string;
-  password?: string;
+  userName: string;
+  password: string;
 }
 
 export interface LoginResponse {
-  accessToken?: string;
+  accessToken: string;
+}
+
+export interface MeResponse {
+  firstName: string;
+  lastName: string;
+  roles: string[];
 }
 
 export interface ResetPasswordRequest {
@@ -81,7 +87,7 @@ export enum ContentType {
 }
 
 export class HttpClient<SecurityDataType = unknown> {
-  public baseUrl: string = "";
+  public baseUrl: string = "http://localhost:8080";
   private securityData: SecurityDataType | null = null;
   private securityWorker?: ApiConfig<SecurityDataType>["securityWorker"];
   private abortControllers = new Map<CancelToken, AbortController>();
@@ -149,8 +155,12 @@ export class HttpClient<SecurityDataType = unknown> {
       input !== null && typeof input !== "string"
         ? JSON.stringify(input)
         : input,
-    [ContentType.FormData]: (input: any) =>
-      Object.keys(input || {}).reduce((formData, key) => {
+    [ContentType.FormData]: (input: any) => {
+      if (input instanceof FormData) {
+        return input;
+      }
+
+      return Object.keys(input || {}).reduce((formData, key) => {
         const property = input[key];
         formData.append(
           key,
@@ -161,7 +171,8 @@ export class HttpClient<SecurityDataType = unknown> {
               : `${property}`,
         );
         return formData;
-      }, new FormData()),
+      }, new FormData());
+    },
     [ContentType.UrlEncoded]: (input: any) => this.toQueryString(input),
   };
 
@@ -247,13 +258,14 @@ export class HttpClient<SecurityDataType = unknown> {
             : payloadFormatter(body),
       },
     ).then(async (response) => {
-      const r = response.clone() as HttpResponse<T, E>;
+      const r = response as HttpResponse<T, E>;
       r.data = null as unknown as T;
       r.error = null as unknown as E;
 
+      const responseToParse = responseFormat ? response.clone() : response;
       const data = !responseFormat
         ? r
-        : await response[responseFormat]()
+        : await responseToParse[responseFormat]()
             .then((data) => {
               if (r.ok) {
                 r.data = data;
@@ -279,6 +291,7 @@ export class HttpClient<SecurityDataType = unknown> {
 /**
  * @title quarkus-auth-adapter-keycloak-refimpl API
  * @version 0.8-SNAPSHOT
+ * @baseUrl http://localhost:8080
  */
 export class Api<
   SecurityDataType extends unknown,
@@ -295,11 +308,12 @@ export class Api<
       data: ForgotPasswordRequest,
       params: RequestParams = {},
     ) =>
-      this.request<void, any>({
+      this.request<any, any>({
         path: `/auth/forgot-password`,
         method: "POST",
         body: data,
         type: ContentType.Json,
+        format: "json",
         ...params,
       }),
 
@@ -316,6 +330,36 @@ export class Api<
         method: "POST",
         body: data,
         type: ContentType.Json,
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Auth Controller
+     * @name LogoutCreate
+     * @request POST:/auth/logout
+     */
+    logoutCreate: (params: RequestParams = {}) =>
+      this.request<any, any>({
+        path: `/auth/logout`,
+        method: "POST",
+        format: "json",
+        ...params,
+      }),
+
+    /**
+     * No description
+     *
+     * @tags Auth Controller
+     * @name GetAuth
+     * @request GET:/auth/me
+     */
+    getAuth: (params: RequestParams = {}) =>
+      this.request<MeResponse, any>({
+        path: `/auth/me`,
+        method: "GET",
         format: "json",
         ...params,
       }),
@@ -346,11 +390,12 @@ export class Api<
       data: ResetPasswordRequest,
       params: RequestParams = {},
     ) =>
-      this.request<void, any>({
+      this.request<any, any>({
         path: `/auth/reset-password`,
         method: "POST",
         body: data,
         type: ContentType.Json,
+        format: "json",
         ...params,
       }),
   };

--- a/refimpl/svelte-refimpl/src/lib/arch/api/ApiHandler.ts
+++ b/refimpl/svelte-refimpl/src/lib/arch/api/ApiHandler.ts
@@ -5,70 +5,79 @@ import accessTokenStore from '../auth/AccessTokenStore';
 import { get } from 'svelte/store';
 
 export default class ApiHandler {
-	static getApi(
-		fetch: (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>,
-		params: RequestParams = {},
-		accessToken?: string | null
-	): Api<unknown> {
-		const baseUrl = env.PUBLIC_BACKEND_URL || new URL(window.location.href).origin;
+  static getApi(
+    fetch: (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>,
+    params: RequestParams = {},
+    accessToken?: string | null
+  ): Api<unknown> {
+    const baseUrl = env.PUBLIC_BACKEND_URL || new URL(window.location.href).origin;
 
-		const baseApiParams: RequestParams = accessToken
-			? {
-					secure: true,
-					headers: {
-						Authorization: `Bearer ${accessToken}`
-					},
-					...params
-				}
-			: {
-					...params
-				};
+    const baseApiParams: RequestParams = accessToken
+      ? {
+          secure: true,
+          headers: {
+            Authorization: `Bearer ${accessToken}`
+          },
+          ...params
+        }
+      : {
+          ...params
+        };
 
-		return new Api({
-			baseUrl,
-			baseApiParams,
-			customFetch: fetch
-		});
-	}
+    return new Api({
+      baseUrl,
+      baseApiParams,
+      customFetch: fetch
+    });
+  }
 
-	static async handle<D>(
-		fetch: (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>,
-		handler: (api: Api<unknown>) => Promise<HttpResponse<D, unknown>>,
-		params: RequestParams = {}
-	): Promise<D | undefined> {
-		const accessToken = get(accessTokenStore);
-		const api = this.getApi(fetch, params, accessToken);
+  static async handle<D>(
+    fetch: (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>,
+    handler: (api: Api<unknown>) => Promise<HttpResponse<D, unknown>>,
+    params: RequestParams = {}
+  ): Promise<D | undefined> {
+    const accessToken = get(accessTokenStore);
+    const api = this.getApi(fetch, params, accessToken);
 
-		// TODO show loading
+    // TODO show loading
 
-		const response = await handler(api);
+    const response = await handler(api);
 
-		if (response.ok) {
-			return response.data || (response.text() as D);
-		} else if (response.status === 401) {
-			await this.refreshAccessToken(fetch);
-		} else {
-			// TODO error handling
-			messageStore.show(response.statusText);
-			return undefined;
-		}
-	}
+    if (response.ok) {
+      return response.data || (response.text() as D);
+    } else if (response.status === 401) {
+      await this.refreshAccessToken(fetch);
+    } else {
+      // TODO error handling
+      messageStore.show(response.statusText);
+      return undefined;
+    }
+  }
 
-	static async refreshAccessToken(
-		fetch: (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>
-	): Promise<void> {
-		console.log('Refreshing access token...');
+  static async refreshAccessToken(
+    fetch: (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>
+  ): Promise<void> {
+    console.log('Refreshing access token...');
 
-		const api = this.getApi(fetch, { credentials: 'include' });
-		const response = await api.auth.refreshTokenList();
+    const api = this.getApi(fetch, { credentials: 'include' });
+    const response = await api.auth.refreshTokenList();
 
-		if (response.ok) {
-			const newAccessToken = response.data.accessToken;
-			accessTokenStore.set(newAccessToken);
-			console.log('Access token refreshed successfully:', newAccessToken);
-		} else {
-			accessTokenStore.set(null);
-			console.error('Failed to refresh access token:', response.status, response.statusText);
-		}
-	}
+    if (response.ok) {
+      const newAccessToken = response.data.accessToken ?? null;
+      accessTokenStore.set(newAccessToken);
+      console.log('Access token refreshed successfully:', newAccessToken);
+    } else {
+      accessTokenStore.set(null);
+      console.error('Failed to refresh access token:', response.status, response.statusText);
+    }
+  }
+
+  static async logout(
+    fetch: (input: RequestInfo | URL, init?: RequestInit | undefined) => Promise<Response>
+  ): Promise<void> {
+    const api = this.getApi(fetch, { credentials: 'include' });
+    await api.auth.logoutCreate();
+    accessTokenStore.set(null);
+    console.log('Logged out successfully');
+  }
 }

--- a/refimpl/svelte-refimpl/src/routes/+layout.svelte
+++ b/refimpl/svelte-refimpl/src/routes/+layout.svelte
@@ -1,60 +1,64 @@
 <script lang="ts">
-	import '@picocss/pico';
-	import { onMount } from 'svelte';
-	import MessagePanel from '$lib/arch/global/MessagePanel.svelte';
-	import accessTokenStore from '$lib/arch/auth/AccessTokenStore';
-	import ApiHandler from '$lib/arch/api/ApiHandler';
+  import '@picocss/pico';
+  import { onMount } from 'svelte';
+  import MessagePanel from '$lib/arch/global/MessagePanel.svelte';
+  import accessTokenStore from '$lib/arch/auth/AccessTokenStore';
+  import ApiHandler from '$lib/arch/api/ApiHandler';
 
-	onMount(async () => {
-		await ApiHandler.refreshAccessToken(fetch);
-	});
+  onMount(async () => {
+    await ApiHandler.refreshAccessToken(fetch);
+  });
+
+  async function logout() {
+    await ApiHandler.logout(fetch);
+  }
 </script>
 
 <nav class="container">
-	<ul>
-		<li><strong>Auth</strong></li>
-	</ul>
-	<ul>
-		<li><a href="/">Top</a></li>
-		{#if $accessTokenStore}
-			<li>
-				<button on:click={() => accessTokenStore.set(null)}>Logout</button>
-			</li>
-			<li id="login-status">Logged in</li>
-		{:else}
-			<li>
-				<a id="loginLink" href="/private">Login</a>
-			</li>
-			<li id="login-status">Not logged in</li>
-		{/if}
-	</ul>
+  <ul>
+    <li><strong>Auth</strong></li>
+  </ul>
+  <ul>
+    <li><a href="/">Top</a></li>
+    {#if $accessTokenStore}
+      <li>
+        <button onclick={logout}>Logout</button>
+      </li>
+      <li id="login-status">Logged in</li>
+    {:else}
+      <li>
+        <a id="loginLink" href="/private">Login</a>
+      </li>
+      <li id="login-status">Not logged in</li>
+    {/if}
+  </ul>
 </nav>
 
 <main class="container">
-	<MessagePanel />
+  <MessagePanel />
 
-	<slot />
+  <slot />
 </main>
 
 <footer class="container">
-	{#if $accessTokenStore}
-		<p class="token">
-			AccessToken: <span id="access-token">{$accessTokenStore}</span>
-		</p>
-	{/if}
+  {#if $accessTokenStore}
+    <p class="token">
+      AccessToken: <span id="access-token">{$accessTokenStore}</span>
+    </p>
+  {/if}
 </footer>
 
 <style>
-	:global(:root) {
-		--pico-font-size: small;
-	}
+  :global(:root) {
+    --pico-font-size: small;
+  }
 
-	main {
-		min-height: 50vh;
-	}
+  main {
+    min-height: 50vh;
+  }
 
-	.token {
-		overflow: scroll;
-		white-space: nowrap;
-	}
+  .token {
+    overflow: scroll;
+    white-space: nowrap;
+  }
 </style>


### PR DESCRIPTION
### Implements logout process

1. The front-end calls the Quarkus logout API as part of the logout process. (The browser automatically sends a cookie containing the refresh token to Quarkus.)

1. Quarkus retrieves the refresh token from the cookie.

1. Quarkus sends a POST request to the Keycloak logout endpoint, including the refresh token. (This deletes the session on the Keycloak side.)

1. POST https://{Keycloak domain}/realms/{realm name}/protocol/openid-connect/logout

1. In the response sent back from Quarkus to the frontend, a cookie of the same name is returned with Max-Age set to 0. (Deletes the cookie on the browser side)